### PR TITLE
[FIX] event.target in _dropdownTap fixed to px-dropdown and drop down…

### DIFF
--- a/px-breadcrumbs.es6.js
+++ b/px-breadcrumbs.es6.js
@@ -83,7 +83,7 @@
     listeners: {
       'iron-resize': '_onResize',
       'px-app-asset-selected': '_onSelect',
-      'px-dropdown-selection-changed': '_dropdownTap',
+      //'px-dropdown-selection-changed': '_dropdownTap',
       'px-app-asset-graph-created': '_getBreadcrumbsObj'
     },
     observers: [
@@ -243,18 +243,36 @@
     },
     /**
      * Handles tap events in the dropdown. Checks each item against the currently selected item.
+     * event.target.selected is pointing to null but evt.detail[evt.target.selectBy] gives actual selected dropdown item
      */
     _dropdownTap(evt) {
-      var newSelectItem = {};
-      if(evt.target && evt.target.items) {
-        evt.target.items.forEach(function(item) {
-          if(item.id === evt.target.selected) {
-            newSelectItem = item;
-          }
-        });
-      }
+      var newSelectItem;
+      var _dropDownSelectedBy = evt.target && evt.target.selectBy || 'key';
+      var _selectedItem = evt.detail;
+      var _dropdownItems = evt.target && evt.target.items;
+      var _validNewItem = _dropdownItems && _dropdownItems.some((item) => {
+        if (item[_dropDownSelectedBy] === _selectedItem[_dropDownSelectedBy]) {
+          newSelectItem = item;
+          return true;
+        }
+        return false;
+      });
       this._changePathFromClick(newSelectItem);
     },
+    /*
+     _dropdownTap(evt) {
+       var newSelectItem = {};
+       if(evt.target && evt.target.items) {
+         evt.target.items.forEach(function(item) {
+           if(item.id === evt.target.selected) {
+             newSelectItem = item;
+           }
+         });
+       }
+       this._changePathFromClick(newSelectItem);
+     },
+    */
+
     /**
      * Sets the _selectedItem to the item that was clicked - whether from the main path items, or the dropdown items.
      * This is the only place we change _selectedItem on click.

--- a/px-breadcrumbs.html
+++ b/px-breadcrumbs.html
@@ -45,10 +45,10 @@ It also provides a quick way to navigate backwards within a path or within a spe
               <span class="actionable actionable--action">[[item.label]]</span>
             </template>
             <template is="dom-if" if="[[_isDropdown(item, clickOnlyMode)]]">
-              <px-dropdown display-value="[[item.label]]" items="[[_clickedItemChildren]]" search-mode="[[searchMode]]" button-style="bare" disable-clear></px-dropdown>
+              <px-dropdown display-value="[[item.label]]" items="[[_clickedItemChildren]]" search-mode="[[searchMode]]" button-style="bare" disable-clear on-px-dropdown-selection-changed="_dropdownTap"></px-dropdown>
             </template>
             <template is="dom-if" if="[[_isOverflow(item)]]">
-              <px-dropdown id="dropdown" items="[[_clickedItemChildren]]" button-style="icon" icon="px-nav:more"></px-dropdown>
+              <px-dropdown id="dropdown" items="[[_clickedItemChildren]]" button-style="icon" icon="px-nav:more" on-px-dropdown-selection-changed="_dropdownTap"></px-dropdown>
             </template>
           </li>
         </template>


### PR DESCRIPTION
… selected item corrected

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
1. event.target in _dropdownTap is was pointing to px-breadcrumbs component instead of px-dropdown, which is a fix proposed in this pull request.
2. dropdown selected item even.target.selected can give null but event.detail[evt.target.selectBy] gives correct dropdown selected item in breadcrumb.

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
