### PR TITLE
Set main path on asset graph created  event

### DIFF
--- a/px-breadcrumbs.html
+++ b/px-breadcrumbs.html
@@ -400,6 +400,7 @@ It also provides a quick way to navigate backwards within a path or within a spe
           clickOnlyMode = this.clickOnlyMode;
       if (!itemPath.length || !graph) return;
       this.set('_breadcrumbsObj', new window.pxBreadcrumbs.Breadcrumbs(this, graph, clickOnlyMode, itemPath, this.keys));
+      this._set_mainPathItems(itemPath)
       this.updateStyles();
     },
     /*


### PR DESCRIPTION
Set Mainpath on initial render

Somehow,

I was running into the issue where the ` _mainPathItems ` was not set while initial render, hence the breadcrumbs was not showing up in the application.

```
<template is="dom-repeat" items="[[_mainPathItems]]">
```

So setting the ` _mainPathItems ` in the  ` 'px-app-asset-graph-created ` events seems to fix it. Hence the change in `_getBreadcrumbsObj ` method.

Not sure if this is the exact fix/ a hack.

Please let me know

I have been trying to create a codepen with the minimal settings, but have not been successful yet.

Will update the PR once I hit on this